### PR TITLE
Potential fix for code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/BuildProcessTemplates/©®™ E.F. Magic/WebApplication2/WebApplication2/Scripts/bootstrap.js
+++ b/BuildProcessTemplates/©®™ E.F. Magic/WebApplication2/WebApplication2/Scripts/bootstrap.js
@@ -668,7 +668,7 @@ if (!jQuery) { throw new Error("Bootstrap requires jQuery") }
     var target  = $this.attr('data-target')
         || e.preventDefault()
         || (href = $this.attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '') //strip for ie7
-    var $target = $(target)
+    var $target = $($.find(target))
     var data    = $target.data('bs.collapse')
     var option  = data ? 'toggle' : $this.data()
     var parent  = $this.attr('data-parent')


### PR DESCRIPTION
Potential fix for [https://github.com/HootanD/github.io-Everlasting-Fairytale-/security/code-scanning/3](https://github.com/HootanD/github.io-Everlasting-Fairytale-/security/code-scanning/3)

To fix this without changing intended functionality, avoid passing untrusted `target` into `$()` directly. Instead, resolve it as a selector within the document context using `$.find`, then wrap the resulting elements with jQuery. This prevents HTML interpretation while preserving selector behavior expected by collapse.

In `BuildProcessTemplates/©®™ E.F. Magic/WebApplication2/WebApplication2/Scripts/bootstrap.js`, update the collapse data-API handler around line 671:

- Replace `var $target = $(target)` with selector-only lookup:
  - `var $target = $($.find(target))`

No new imports or helper methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
